### PR TITLE
Adminページの議案順序とフラグの変更ページを実装した

### DIFF
--- a/apps/admin/controllers/article_number/edit.rb
+++ b/apps/admin/controllers/article_number/edit.rb
@@ -1,13 +1,17 @@
 module Admin::Controllers::ArticleNumber
   class Edit
     include Admin::Action
+    expose :meeting
     expose :articles
 
-    def initialize(article_repo: ArticleRepository.new)
+    def initialize(meeting_repo: MeetingRepository.new,
+                   article_repo: ArticleRepository.new)
+      @meeting_repo = meeting_repo
       @article_repo = article_repo
     end
 
     def call(params)
+      @meeting = @meeting_repo.find(params[:id])
       @articles = @article_repo.by_meeting(params[:id])
     end
   end

--- a/apps/admin/controllers/article_number/edit.rb
+++ b/apps/admin/controllers/article_number/edit.rb
@@ -2,17 +2,13 @@ module Admin::Controllers::ArticleNumber
   class Edit
     include Admin::Action
     expose :meeting
-    expose :articles
 
-    def initialize(meeting_repo: MeetingRepository.new,
-                   article_repo: ArticleRepository.new)
+    def initialize(meeting_repo: MeetingRepository.new)
       @meeting_repo = meeting_repo
-      @article_repo = article_repo
     end
 
     def call(params)
-      @meeting = @meeting_repo.find(params[:id])
-      @articles = @article_repo.by_meeting(params[:id])
+      @meeting = @meeting_repo.find_with_articles(params[:id])
     end
   end
 end

--- a/apps/admin/controllers/article_number/update.rb
+++ b/apps/admin/controllers/article_number/update.rb
@@ -1,13 +1,36 @@
+require 'hanami/validations'
+
 module Admin::Controllers::ArticleNumber
   class Update
     include Admin::Action
     expose :meeting
 
-    params do
-      required(:meeting).schema do
-        required(:articles) { array? { each { hash? }}}
+    params Class.new(Hanami::Action::Params) {
+      predicate(:int_values?, message: 'is not int values'){ |current|
+        !current['number'].nil? && !current['article_id'].nil? &&
+          current['number'].match(/\d+|/) && current['article_id'].match(/\d+|/)
+      }
+      predicate(:unique_array?, message: 'is not unique'){ |current|
+        return false unless current.instance_of?(Array)
+
+        numbers = current.map{ |item|
+          if item['number'].nil? || item['number'].eql?("")
+            0
+          else
+            item['number'].to_i
+          end
+        }.select{ |item| item.positive? } # select greater than 0
+        max = numbers.count
+        numbers.sort == (1..max).to_a
+      }
+
+      validations do
+        required(:meeting).schema do
+          required(:articles) { unique_array? { each { int_values? }}}
+        end
       end
-    end
+    }
+
 
     def initialize(meeting_repo: MeetingRepository.new,
                    article_repo: ArticleRepository.new)

--- a/apps/admin/controllers/article_number/update.rb
+++ b/apps/admin/controllers/article_number/update.rb
@@ -17,11 +17,9 @@ module Admin::Controllers::ArticleNumber
     end
 
     def call(params)
-      Hanami.logger.info params[:meeting].inspect
       if params.valid?
-        params[:meeting][:articles].each do |params_hash|
-          @article_repo.update_number(params_hash)
-        end
+        articles_number = params[:meeting][:articles]
+        @article_repo.update_number(articles_number)
         redirect_to routes.meeting_path(id: params[:id])
       else
         @meeting = @meeting_repo.find(params[:id])

--- a/apps/admin/controllers/article_number/update.rb
+++ b/apps/admin/controllers/article_number/update.rb
@@ -22,8 +22,7 @@ module Admin::Controllers::ArticleNumber
         @article_repo.update_number(articles_number)
         redirect_to routes.meeting_path(id: params[:id])
       else
-        @meeting = @meeting_repo.find(params[:id])
-        @articles = @article_repo.by_meeting(params[:id])
+        @meeting = @meeting_repo.find_with_articles(params[:id])
       end
     end
   end

--- a/apps/admin/controllers/article_number/update.rb
+++ b/apps/admin/controllers/article_number/update.rb
@@ -19,7 +19,7 @@ module Admin::Controllers::ArticleNumber
     def call(params)
       if params.valid?
         articles_number = params[:meeting][:articles]
-        @article_repo.update_number(articles_number)
+        @article_repo.update_number(params[:id], articles_number)
         redirect_to routes.meeting_path(id: params[:id])
       else
         @meeting = @meeting_repo.find_with_articles(params[:id])

--- a/apps/admin/controllers/article_number/update.rb
+++ b/apps/admin/controllers/article_number/update.rb
@@ -28,6 +28,7 @@ module Admin::Controllers::ArticleNumber
         required(:meeting).schema do
           required(:articles) { unique_array? { each { int_values? }}}
         end
+        required(:id).filled(:int?)
       end
     }
 
@@ -45,6 +46,7 @@ module Admin::Controllers::ArticleNumber
         redirect_to routes.meeting_path(id: params[:id])
       else
         @meeting = @meeting_repo.find_with_articles(params[:id])
+        self.status = 422
       end
     end
   end

--- a/apps/admin/controllers/article_number/update.rb
+++ b/apps/admin/controllers/article_number/update.rb
@@ -1,7 +1,32 @@
 module Admin::Controllers::ArticleNumber
   class Update
     include Admin::Action
+    expose :meeting
+    expose :articles
 
-    def call(params) end
+    params do
+      required(:meeting).schema do
+        required(:articles) { array? { each { hash? }}}
+      end
+    end
+
+    def initialize(meeting_repo: MeetingRepository.new,
+                   article_repo: ArticleRepository.new)
+      @meeting_repo = meeting_repo
+      @article_repo = article_repo
+    end
+
+    def call(params)
+      Hanami.logger.info params[:meeting].inspect
+      if params.valid?
+        params[:meeting][:articles].each do |params_hash|
+          @article_repo.update_number(params_hash)
+        end
+        redirect_to routes.meeting_path(id: params[:id])
+      else
+        @meeting = @meeting_repo.find(params[:id])
+        @articles = @article_repo.by_meeting(params[:id])
+      end
+    end
   end
 end

--- a/apps/admin/controllers/article_number/update.rb
+++ b/apps/admin/controllers/article_number/update.rb
@@ -2,7 +2,6 @@ module Admin::Controllers::ArticleNumber
   class Update
     include Admin::Action
     expose :meeting
-    expose :articles
 
     params do
       required(:meeting).schema do

--- a/apps/admin/controllers/article_status/update.rb
+++ b/apps/admin/controllers/article_status/update.rb
@@ -14,6 +14,7 @@ module Admin::Controllers::ArticleStatus
           end
         end
       end
+      required(:id).filled(:int?)
     end
 
     def initialize(meeting_repo: MeetingRepository.new,
@@ -29,6 +30,7 @@ module Admin::Controllers::ArticleStatus
         redirect_to routes.meeting_path(id: params[:id])
       else
         @meeting = @meeting_repo.find_with_articles(params[:id])
+        self.status = 422
       end
     end
   end

--- a/apps/admin/templates/article_number/edit.html.erb
+++ b/apps/admin/templates/article_number/edit.html.erb
@@ -1,6 +1,2 @@
 <h1>議案並び替え</h1>
-<ul>
-  <% articles.each do |article| %>
-    <li><%= article.title %></li>
-  <% end %>
-</ul>
+<%= form(meeting, articles) %>

--- a/apps/admin/templates/article_number/edit.html.erb
+++ b/apps/admin/templates/article_number/edit.html.erb
@@ -1,2 +1,2 @@
 <h1>議案並び替え</h1>
-<%= form(meeting, articles) %>
+<%= form(meeting) %>

--- a/apps/admin/templates/article_number/update.html.erb
+++ b/apps/admin/templates/article_number/update.html.erb
@@ -1,0 +1,2 @@
+<h1>議案並び替え</h1>
+<%= form(meeting, articles) %>

--- a/apps/admin/templates/article_number/update.html.erb
+++ b/apps/admin/templates/article_number/update.html.erb
@@ -1,2 +1,2 @@
 <h1>議案並び替え</h1>
-<%= form(meeting, articles) %>
+<%= form(meeting) %>

--- a/apps/admin/views/article_number/edit.rb
+++ b/apps/admin/views/article_number/edit.rb
@@ -1,5 +1,8 @@
+require_relative './form'
+
 module Admin::Views::ArticleNumber
   class Edit
     include Admin::View
+    include Form
   end
 end

--- a/apps/admin/views/article_number/form.rb
+++ b/apps/admin/views/article_number/form.rb
@@ -11,18 +11,17 @@ module Admin::Views::ArticleNumber
         articles.each_with_index do |article, idx|
           value = article.number
           div do
-            label article.title
-            div do
-              label 'article number'
-              number_field :article_number, min: 1,
-                                            max: max,
-                                            step: 1,
-                                            value: value,
-                                            name: "meeting[articles][][number]",
-                                            id: "meeting-articles-#{idx}-number"
-              hidden_field :article_id, name: "meeting[articles][][article_id]",
-                                        value: article.id
-            end
+            label article.title, for: "meeting-articles-#{idx}-article_id"
+            hidden_field :article_id, name: "meeting[articles][][article_id]",
+                                      id: "meeting-articles-#{idx}-article_id",
+                                      value: article.id
+            label 'article number', for: "meeting-articles-#{idx}-number"
+            number_field :article_number, name: "meeting[articles][][number]",
+                                          id: "meeting-articles-#{idx}-number",
+                                          min: 1,
+                                          max: max,
+                                          step: 1,
+                                          value: value
           end
         end
 

--- a/apps/admin/views/article_number/form.rb
+++ b/apps/admin/views/article_number/form.rb
@@ -17,7 +17,7 @@ module Admin::Views::ArticleNumber
                                             max: max,
                                             step: 1,
                                             value: value,
-                                            name: "meeting[articles][][article_number]",
+                                            name: "meeting[articles][][number]",
                                             id: "meeting-articles-#{idx}-number"
               hidden_field :article_id, name: "meeting[articles][][article_id]",
                                         value: article.id

--- a/apps/admin/views/article_number/form.rb
+++ b/apps/admin/views/article_number/form.rb
@@ -1,6 +1,7 @@
 module Admin::Views::ArticleNumber
   module Form
     def form(meeting, articles)
+      return if articles.nil? || articles.count == 0
       max = articles.count
 
       form_for :meeting,

--- a/apps/admin/views/article_number/form.rb
+++ b/apps/admin/views/article_number/form.rb
@@ -1,0 +1,32 @@
+module Admin::Views::ArticleNumber
+  module Form
+    def form(meeting, articles)
+      max = articles.count
+
+      form_for :meeting,
+               routes.update_article_number_path(id: meeting.id),
+               method: :patch do
+
+        articles.each_with_index do |article, idx|
+          value = article.number
+          div do
+            label article.title
+            div do
+              label 'article number'
+              number_field :article_number, min: 1,
+                                            max: max,
+                                            step: 1,
+                                            value: value,
+                                            name: "meeting[articles][][article_number]",
+                                            id: "meeting-articles-#{idx}-number"
+              hidden_field :article_id, name: "meeting[articles][][article_id]",
+                                        value: article.id
+            end
+          end
+        end
+
+        submit 'Send'
+      end
+    end
+  end
+end

--- a/apps/admin/views/article_number/form.rb
+++ b/apps/admin/views/article_number/form.rb
@@ -1,14 +1,14 @@
 module Admin::Views::ArticleNumber
   module Form
-    def form(meeting, articles)
-      return if articles.nil? || articles.count == 0
-      max = articles.count
+    def form(meeting)
+      return if meeting.articles.nil? || meeting.articles.count == 0
+      max = meeting.articles.count
 
       form_for :meeting,
                routes.article_number_path(id: meeting.id),
                method: :patch do
 
-        articles.each_with_index do |article, idx|
+        meeting.articles.each_with_index do |article, idx|
           value = article.number
           div do
             label article.title, for: "meeting-articles-#{idx}-article_id"

--- a/apps/admin/views/article_number/form.rb
+++ b/apps/admin/views/article_number/form.rb
@@ -5,7 +5,7 @@ module Admin::Views::ArticleNumber
       max = articles.count
 
       form_for :meeting,
-               routes.update_article_number_path(id: meeting.id),
+               routes.article_number_path(id: meeting.id),
                method: :patch do
 
         articles.each_with_index do |article, idx|

--- a/apps/admin/views/article_number/update.rb
+++ b/apps/admin/views/article_number/update.rb
@@ -1,5 +1,8 @@
+require_relative './form'
+
 module Admin::Views::ArticleNumber
   class Update
     include Admin::View
+    include Form
   end
 end

--- a/lib/kumanodocs_hanami/repositories/article_repository.rb
+++ b/lib/kumanodocs_hanami/repositories/article_repository.rb
@@ -5,11 +5,8 @@ class ArticleRepository < Hanami::Repository
 
   def update_number(articles_number)
     articles_number.each do |article_attr|
-      if !article_attr['number'].eql?("")
-        update(article_attr['article_id'], number: article_attr['number'])
-      else
-        update(article_attr['article_id'], number: nil)
-      end
+      num = article_attr['number'].eql?("") ? nil : article_attr['number']
+      update(article_attr['article_id'], number: num)
     end
   end
 

--- a/lib/kumanodocs_hanami/repositories/article_repository.rb
+++ b/lib/kumanodocs_hanami/repositories/article_repository.rb
@@ -3,6 +3,10 @@ class ArticleRepository < Hanami::Repository
     belongs_to :author
   end
 
+  def update_number(params_hash)
+    update(params_hash['article_id'], number: params_hash['number'])
+  end
+
   def group_by_meeting
     articles.to_a
             .group_by { |article| article.meeting_id }

--- a/lib/kumanodocs_hanami/repositories/article_repository.rb
+++ b/lib/kumanodocs_hanami/repositories/article_repository.rb
@@ -3,8 +3,10 @@ class ArticleRepository < Hanami::Repository
     belongs_to :author
   end
 
-  def update_number(params_hash)
-    update(params_hash['article_id'], number: params_hash['number'])
+  def update_number(articles_number)
+    articles_number.each do |article_attr|
+      update(article_attr['article_id'], number: article_attr['number'])
+    end
   end
 
   def update_status(articles_status)

--- a/lib/kumanodocs_hanami/repositories/article_repository.rb
+++ b/lib/kumanodocs_hanami/repositories/article_repository.rb
@@ -3,7 +3,9 @@ class ArticleRepository < Hanami::Repository
     belongs_to :author
   end
 
-  def update_number(articles_number)
+  def update_number(meeting_id, articles_number)
+    # numberをnilで初期化してからupdateする
+    articles.where(meeting_id: meeting_id).update(number: nil)
     articles_number.each do |article_attr|
       num = article_attr['number'].eql?("") ? nil : article_attr['number']
       update(article_attr['article_id'], number: num)

--- a/lib/kumanodocs_hanami/repositories/article_repository.rb
+++ b/lib/kumanodocs_hanami/repositories/article_repository.rb
@@ -5,7 +5,11 @@ class ArticleRepository < Hanami::Repository
 
   def update_number(articles_number)
     articles_number.each do |article_attr|
-      update(article_attr['article_id'], number: article_attr['number'])
+      if !article_attr['number'].eql?("")
+        update(article_attr['article_id'], number: article_attr['number'])
+      else
+        update(article_attr['article_id'], number: nil)
+      end
     end
   end
 

--- a/lib/kumanodocs_hanami/repositories/meeting_repository.rb
+++ b/lib/kumanodocs_hanami/repositories/meeting_repository.rb
@@ -13,11 +13,16 @@ class MeetingRepository < Hanami::Repository
   end
 
   def find_with_articles(meeting_id)
-    aggregate(:articles)
+    meeting = aggregate(:articles)
       .meetings
       .where(id: meeting_id)
       .as(Meeting)
       .one
+    # articlesの順序をnumberでソート
+    meeting.articles.sort_by!{ |article|
+      article.number.nil? ? 10000 : article.number.to_i
+    }
+    meeting
   end
 
   # 締め切り前の議案一覧

--- a/spec/admin/controllers/article_number/edit_spec.rb
+++ b/spec/admin/controllers/article_number/edit_spec.rb
@@ -3,10 +3,15 @@ require_relative '../../../../apps/admin/controllers/article_number/edit'
 
 describe Admin::Controllers::ArticleNumber::Edit do
   let(:action) { Admin::Controllers::ArticleNumber::Edit.new }
-  let(:params) { Hash[] }
+  let(:meeting_repo) { MeetingRepository.new }
+  let(:article) { create(:article) }
+  let(:params) { {id: article.meeting_id} }
 
   it 'is successful' do
+    _meeting = meeting_repo.find_with_articles(article.meeting_id)
     response = action.call(params)
     response[0].must_equal 200
+
+    action.meeting.must_equal _meeting
   end
 end

--- a/spec/admin/controllers/article_number/update_spec.rb
+++ b/spec/admin/controllers/article_number/update_spec.rb
@@ -3,10 +3,31 @@ require_relative '../../../../apps/admin/controllers/article_number/update'
 
 describe Admin::Controllers::ArticleNumber::Update do
   let(:action) { Admin::Controllers::ArticleNumber::Update.new }
-  let(:params) { Hash[] }
+  let(:article_repo) { ArticleRepository.new }
+  let(:articles) { create_list(:article, 5) }
+  let(:meeting) { create(:meeting) }
 
   it 'is successful' do
+    numbers = ["1", "2", "3"].shuffle
+    articles.each { |article|
+      article_repo.update(article.id, meeting_id: meeting.id)
+    }
+    article_params = articles.sample(3).map.with_index { |article, index| {'article_id' => "#{article.id}", 'number' => numbers[index]} }
+    params = {id: meeting.id, meeting: {articles: article_params} }
+
     response = action.call(params)
-    response[0].must_equal 200
+    response[0].must_equal 302
+  end
+
+  it 'is rejected' do
+    numbers = ["1", "1", "3"].shuffle
+    articles.each { |article|
+      article_repo.update(article.id, meeting_id: meeting.id)
+    }
+    article_params = articles.sample(3).map.with_index { |article, index| {'article_id' => "#{article.id}", 'number' => numbers[index]} }
+    params = {id: meeting.id, meeting: {articles: article_params} }
+
+    response = action.call(params)
+    response[0].must_equal 422
   end
 end

--- a/spec/admin/controllers/article_number/update_spec.rb
+++ b/spec/admin/controllers/article_number/update_spec.rb
@@ -17,6 +17,11 @@ describe Admin::Controllers::ArticleNumber::Update do
 
     response = action.call(params)
     response[0].must_equal 302
+
+    article_params.each_with_index do |hash, index|
+      _article = article_repo.find(hash['article_id'].to_i)
+      _article.number.must_equal numbers[index].to_i
+    end
   end
 
   it 'is rejected' do

--- a/spec/admin/controllers/article_status/edit_spec.rb
+++ b/spec/admin/controllers/article_status/edit_spec.rb
@@ -3,10 +3,15 @@ require_relative '../../../../apps/admin/controllers/article_status/edit'
 
 describe Admin::Controllers::ArticleStatus::Edit do
   let(:action) { Admin::Controllers::ArticleStatus::Edit.new }
-  let(:params) { Hash[] }
+  let(:meeting_repo) { MeetingRepository.new }
+  let(:article) { create(:article) }
 
   it 'is successful' do
-    response = action.call(params)
+    _meeting = meeting_repo.find_with_articles(article.meeting_id)
+
+    response = action.call(id: article.meeting_id)
     response[0].must_equal 200
+
+    action.meeting.must_equal _meeting
   end
 end

--- a/spec/admin/controllers/article_status/update_spec.rb
+++ b/spec/admin/controllers/article_status/update_spec.rb
@@ -3,10 +3,20 @@ require_relative '../../../../apps/admin/controllers/article_status/update'
 
 describe Admin::Controllers::ArticleStatus::Update do
   let(:action) { Admin::Controllers::ArticleStatus::Update.new }
-  let(:params) { Hash[] }
+  let(:article_repo) { ArticleRepository.new }
+  let(:article) { create(:article) }
+  let(:article_param) { {'article_id' => article.id, 'checked' => [true, nil].sample, 'printed' => [true, nil].sample} }
+  let(:articles_params) { [article_param] }
+  let(:meeting_params) { {articles: articles_params} }
+  let(:params) { {meeting: meeting_params, id: article.meeting_id} }
 
   it 'is successful' do
     response = action.call(params)
-    response[0].must_equal 200
+    response[0].must_equal 302
+  end
+
+  it 'is rejected' do
+    response = action.call(id: article.meeting_id)
+    response[0].must_equal 422
   end
 end

--- a/spec/admin/controllers/article_status/update_spec.rb
+++ b/spec/admin/controllers/article_status/update_spec.rb
@@ -13,6 +13,10 @@ describe Admin::Controllers::ArticleStatus::Update do
   it 'is successful' do
     response = action.call(params)
     response[0].must_equal 302
+
+    _article = article_repo.find(article.id)
+    _article.checked.must_equal !article_param['checked'].nil?
+    _article.printed.must_equal !article_param['printed'].nil?
   end
 
   it 'is rejected' do

--- a/spec/admin/controllers/meeting/index_spec.rb
+++ b/spec/admin/controllers/meeting/index_spec.rb
@@ -3,10 +3,14 @@ require_relative '../../../../apps/admin/controllers/meeting/index'
 
 describe Admin::Controllers::Meeting::Index do
   let(:action) { Admin::Controllers::Meeting::Index.new }
+  let(:meeting_repo) { MeetingRepository.new }
   let(:params) { Hash[] }
 
   it 'is successful' do
+    _meetings = meeting_repo.desc_by_date
     response = action.call(params)
     response[0].must_equal 200
+
+    action.meetings.must_equal _meetings
   end
 end

--- a/spec/admin/controllers/meeting/show_spec.rb
+++ b/spec/admin/controllers/meeting/show_spec.rb
@@ -3,10 +3,15 @@ require_relative '../../../../apps/admin/controllers/meeting/show'
 
 describe Admin::Controllers::Meeting::Show do
   let(:action) { Admin::Controllers::Meeting::Show.new }
-  let(:params) { Hash[] }
+  let(:meeting_repo) { MeetingRepository.new }
+  let(:meeting) { create(:meeting) }
+  let(:params) { {id: meeting.id} }
 
   it 'is successful' do
+    _meeting = meeting_repo.find(meeting.id)
     response = action.call(params)
     response[0].must_equal 200
+
+    action.meeting.must_equal _meeting
   end
 end

--- a/spec/factories/article.rb
+++ b/spec/factories/article.rb
@@ -4,6 +4,9 @@ FactoryGirl.define do
     body  { Faker::Lorem.paragraphs.join }
     author_id { create(:author).id }
     meeting_id { create(:meeting).id }
+    number { nil }
+    checked { false }
+    printed { false }
 
     initialize_with { new(attributes) }
 


### PR DESCRIPTION
議案の順序を変更するためのarticle_number#edit, updateと
議案のチェック済み、印刷済みフラグを変更するためのarticle_status#edit, updateを実装した。
それぞれのアクションのテストも記述した。