### PR TITLE
Webページの議案削除時にパスワードを確認してから削除するように修正

### DIFF
--- a/apps/web/controllers/article/destroy.rb
+++ b/apps/web/controllers/article/destroy.rb
@@ -1,14 +1,23 @@
 module Web::Controllers::Article
   class Destroy
     include Web::Action
+    expose :article
 
     def initialize(article_repo: ArticleRepository.new)
       @article_repo = article_repo
     end
 
     def call(params)
-      @article_repo.delete(params[:id])
-      redirect_to routes.articles_path
+      @article = @article_repo.find_with_relations(params[:id])
+      # パスワード入力画面から遷移してきてパラメータにパスワードがある場合
+      if !params[:article].nil?
+        if @article.author.authenticate(params[:article][:password])
+          @article_repo.delete(params[:id])
+          redirect_to routes.articles_path
+        else
+          self.status = 401
+        end
+      end
     end
   end
 end

--- a/apps/web/templates/article/destroy.html.erb
+++ b/apps/web/templates/article/destroy.html.erb
@@ -1,0 +1,3 @@
+<h1><%= article.title %></h1>
+<p>上記の議案を削除します。パスワードを入力してください</p>
+<%= form_destroy(article) %>

--- a/apps/web/views/article/destroy.rb
+++ b/apps/web/views/article/destroy.rb
@@ -1,0 +1,6 @@
+module Web::Views::Article
+  class Destroy
+    include Web::View
+    include Form
+  end
+end

--- a/apps/web/views/article/form.rb
+++ b/apps/web/views/article/form.rb
@@ -97,5 +97,16 @@ module Web::Views::Article
         submit '保存'
       end
     end
+
+    def form_destroy(article)
+      form_for :article, routes.article_path(id: article.id), method: :delete, class: 'delete_article' do
+        div do
+          label 'パスワード', for: :password
+          password_field :password
+        end
+
+        submit '削除'
+      end
+    end
   end
 end


### PR DESCRIPTION
議案投稿者のみが削除できる状態が適切なので、正しいパスワードを入力しなければ削除できないよう修正した