### PR TITLE
Webページのarticle関連のコントローラのテストを修正した

### DIFF
--- a/apps/web/controllers/article/update.rb
+++ b/apps/web/controllers/article/update.rb
@@ -4,6 +4,7 @@ module Web::Controllers::Article
     expose :meetings, :categories, :confirm_update
 
     params do
+      required(:id).filled(:int?)
       required(:article).schema do
         required(:meeting_id).filled(:int?)
         required(:categories) { array? { min_size?(1) & each { int? } } }

--- a/spec/web/controllers/article/create_spec.rb
+++ b/spec/web/controllers/article/create_spec.rb
@@ -2,12 +2,63 @@ require 'spec_helper'
 require_relative '../../../../apps/web/controllers/article/create'
 
 describe Web::Controllers::Article::Create do
-  let(:action) { Web::Controllers::Article::Create.new }
+  let(:article) { Article.new(id: rand(1..5), meeting_id: valid_params[:article][:meeting_id]) }
+  let(:meetings) { [Meeting.new(id: rand(1..5))] }
+  let(:categories) { [Category.new(id: rand(1..5))] }
+  let(:author) { Author.new( author_params.merge(id: rand(1..5)) ) }
   let(:params) { Hash[] }
+  let(:author_params) {
+    password = Faker::Internet.password
+    {
+      name: Faker::Name.name,
+      password: password,
+      password_confirmation: password
+    }
+  }
+  let(:valid_params) {
+    {
+      article: {
+        meeting_id: rand(1..5),
+        categories: [1, 2, 3, 4].sample(2),
+        title: Faker::Book.title,
+        body: Faker::Lorem.paragraphs.join,
+        author: author_params
+      }
+    }
+  }
 
   it 'is successful' do
-    skip
+    categories_params = valid_params[:article][:categories].map{ |id| {category_id: id} }
+    author_repo = MiniTest::Mock.new.expect(
+      :create_with_plain_password, author, [author_params[:name], author_params[:password]]
+    )
+    article_repo = MiniTest::Mock.new.expect(
+      :create, article, [valid_params[:article].merge(author_id: author.id)]
+    ).expect(
+      :add_categories, nil, [article, categories_params]
+    )
+    action = Web::Controllers::Article::Create.new(
+      author_repo: author_repo,
+      article_repo: article_repo
+    )
+    response = action.call(valid_params)
+
+    response[0].must_equal 302
+    author_repo.verify.must_equal true
+    article_repo.verify.must_equal true
+  end
+
+  it 'is rejected' do
+    meeting_repo = MiniTest::Mock.new.expect(:in_time, meetings)
+    category_repo = MiniTest::Mock.new.expect(:all, categories)
+    action = Web::Controllers::Article::Create.new(
+      meeting_repo: meeting_repo,
+      category_repo: category_repo
+    )
     response = action.call(params)
-    response[0].must_equal 200
+    
+    response[0].must_equal 422
+    meeting_repo.verify.must_equal true
+    category_repo.verify.must_equal true
   end
 end

--- a/spec/web/controllers/article/destroy_spec.rb
+++ b/spec/web/controllers/article/destroy_spec.rb
@@ -4,12 +4,27 @@ require_relative '../../../../apps/web/controllers/article/destroy'
 describe Web::Controllers::Article::Destroy do
   let(:action) { Web::Controllers::Article::Destroy.new }
   let(:article_repo) { ArticleRepository.new }
+  let(:author_repo) { AuthorRepository.new }
+  let(:author_name) { Faker::Name.name }
+  let(:password) { Faker::Internet.password }
 
   it 'is successful' do
-    article = create(:article)
+    author = author_repo.create_with_plain_password(author_name, password)
+    article = create(:article, author_id: author.id)
     pre_article_count = article_repo.all.count
-    response = action.call({id: article.id})
+    params = { id: article.id, article: {password: password} }
+
+    response = action.call(params)
+
     response[0].must_equal 302
     article_repo.all.count.must_equal pre_article_count - 1
+  end
+
+  it 'is rejected' do
+    author = author_repo.create_with_plain_password(author_name, password)
+    article = create(:article, author_id: author.id)
+    params = { id: article.id, article: {password: password + "hoge"} }
+    response = action.call(params)
+    response[0].must_equal 401
   end
 end

--- a/spec/web/controllers/article/edit_spec.rb
+++ b/spec/web/controllers/article/edit_spec.rb
@@ -2,12 +2,35 @@ require 'spec_helper'
 require_relative '../../../../apps/web/controllers/article/edit'
 
 describe Web::Controllers::Article::Edit do
-  let(:action) { Web::Controllers::Article::Edit.new }
-  let(:params) { Hash[] }
+  let(:article) { create(:article) }
+  let(:meeting) { Meeting.new(id: article.meeting_id) }
+  let(:article_repo) { ArticleRepository.new }
+  let(:author_repo) { AuthorRepository.new }
+  let(:categories) { [Category.new(id: rand(1..5))] }
+  let(:params) { {id: article.id} }
 
   it 'is successful' do
-    skip
+    meeting_repo = MiniTest::Mock.new.expect(:in_time, [meeting])
+    category_repo = MiniTest::Mock.new.expect(:all, categories)
+    action = Web::Controllers::Article::Edit.new(
+      article_repo: article_repo,
+      meeting_repo: meeting_repo,
+      category_repo: category_repo
+    )
+    lock_key = author_repo.lock(article.author_id, '')
+    params.merge!("HTTP_COOKIE"=>"article_lock_key=#{lock_key}")
+
     response = action.call(params)
+
     response[0].must_equal 200
+    meeting_repo.verify.must_equal true
+    category_repo.verify.must_equal true
+  end
+
+  it 'is rejected' do
+    action = Web::Controllers::Article::Edit.new(article_repo: article_repo)
+    response = action.call(params)
+    # ロックを取るページへリダイレクトすることを確認
+    response[0].must_equal 302
   end
 end

--- a/spec/web/controllers/article/new_spec.rb
+++ b/spec/web/controllers/article/new_spec.rb
@@ -2,12 +2,19 @@ require 'spec_helper'
 require_relative '../../../../apps/web/controllers/article/new'
 
 describe Web::Controllers::Article::New do
-  let(:action) { Web::Controllers::Article::New.new }
+  let(:meetings) { [Meeting.new(id: rand(1..5))] }
+  let(:categories) { [Category.new(id: rand(1..5))] }
   let(:params) { Hash[] }
 
   it 'is successful' do
-    skip
+    action = Web::Controllers::Article::New.new(
+      meeting_repository: MiniTest::Mock.new.expect(:in_time, meetings),
+      category_repository: MiniTest::Mock.new.expect(:all, categories)
+    )
     response = action.call(params)
+
+    action.meetings.must_equal meetings
+    action.categories.must_equal categories
     response[0].must_equal 200
   end
 end

--- a/spec/web/controllers/article/update_spec.rb
+++ b/spec/web/controllers/article/update_spec.rb
@@ -2,12 +2,75 @@ require 'spec_helper'
 require_relative '../../../../apps/web/controllers/article/update'
 
 describe Web::Controllers::Article::Update do
-  let(:action) { Web::Controllers::Article::Update.new }
-  let(:params) { Hash[] }
+  def assert_invalid_params(invalid_params_merged)
+    meeting_repo_mock = MiniTest::Mock.new.expect(:in_time, [Meeting.new(id: rand(1..5))])
+    category_repo_mock = MiniTest::Mock.new.expect(:all, [Category.new(id: rand(1..5))])
+    action = Web::Controllers::Article::Update.new(
+      meeting_repo: meeting_repo_mock,
+      category_repo: category_repo_mock
+    )
+    invalid_params = valid_params.deep_merge(invalid_params_merged)
+
+    response = action.call(invalid_params)
+    response[0].must_equal 422
+    meeting_repo_mock.verify.must_equal true
+    category_repo_mock.verify.must_equal true
+  end
+
+  let(:article) { create(:article) }
+  let(:article_repo) { ArticleRepository.new }
+  let(:author_repo) { AuthorRepository.new }
+  let(:valid_params) {
+    {
+      id: article.id,
+      article: {
+        meeting_id: rand(1..5),
+        categories: [1,2,3,4].sample(2),
+        title: Faker::Book.title,
+        body: Faker::Lorem.paragraphs.join,
+        author: {name: Faker::Name.name},
+        get_lock: false
+      }
+    }
+  }
 
   it 'is successful' do
-    skip
+    lock_key = author_repo.lock(article.author_id, '')
+    article_with_author = article_repo.find_with_relations(article.id)
+    category_params = valid_params[:article][:categories].map{ |id| {category_id: id} }
+
+    article_repo_mock = MiniTest::Mock.new.expect(
+      :find_with_relations, article_with_author, [valid_params[:id]]
+    ).expect(
+      :update_categories, nil, [article_with_author, category_params]
+    ).expect(
+      :update, nil, [article.id, valid_params[:article]]
+    )
+    author_repo_mock = MiniTest::Mock.new.expect(
+      :update, nil, [article.author_id, valid_params[:article][:author]]
+    ).expect(
+      :release_lock, nil, [article.author_id]
+    )
+    action = Web::Controllers::Article::Update.new(
+      article_repo: article_repo_mock,
+      author_repo: author_repo_mock
+    )
+    params = valid_params.merge("HTTP_COOKIE"=>"article_lock_key=#{lock_key}")
     response = action.call(params)
-    response[0].must_equal 200
+
+    response[0].must_equal 302
+    article_repo_mock.verify.must_equal true
+    author_repo_mock.verify.must_equal true
+  end
+
+  it 'is rejected' do
+    assert_invalid_params(article: { title: nil })
+    assert_invalid_params(article: { body: nil })
+    assert_invalid_params(article: { meeting_id: "hoge" })
+    assert_invalid_params(article: { meeting_id: nil })
+    assert_invalid_params(article: { categories: [] })
+    assert_invalid_params(article: { categories: nil })
+    assert_invalid_params(article: { categories: "hoge" })
+    assert_invalid_params(article: { author: { name: nil } })
   end
 end


### PR DESCRIPTION
以下のコントローラに対応するテストを修正した。
- `web#article#new`
- `web#article#create`
- `web#article#edit`
- `web#article#update`
- `web#article#destroy`