### PR TITLE
Webページにmeeting#index, showアクションを追加した

### DIFF
--- a/apps/web/application.rb
+++ b/apps/web/application.rb
@@ -18,7 +18,7 @@ module Web
       #
       # When you add new directories, remember to add them here.
       #
-      load_paths << %w[controllers views]
+      load_paths << %w[controllers helpers views]
 
       # Handle exceptions with HTTP statuses (true) or don't catch them (false).
       # Defaults to true.
@@ -267,6 +267,7 @@ module Web
       view.prepare do
         include Hanami::Helpers
         include Web::Assets::Helpers
+        include Web::Helpers::ArticleHelper
       end
     end
 

--- a/apps/web/config/routes.rb
+++ b/apps/web/config/routes.rb
@@ -7,4 +7,4 @@ root to: 'article#index'
 resources :article do
   resource :lock, only: [:new, :create]
 end
-resources :meeting, only: [:index]
+resources :meeting, only: [:index, :show]

--- a/apps/web/config/routes.rb
+++ b/apps/web/config/routes.rb
@@ -7,3 +7,4 @@ root to: 'article#index'
 resources :article do
   resource :lock, only: [:new, :create]
 end
+resources :meeting, only: [:index]

--- a/apps/web/controllers/meeting/index.rb
+++ b/apps/web/controllers/meeting/index.rb
@@ -1,0 +1,14 @@
+module Web::Controllers::Meeting
+  class Index
+    include Web::Action
+    expose :meetings
+
+    def initialize(meeting_repo: MeetingRepository.new)
+      @meeting_repo = meeting_repo
+    end
+
+    def call(params)
+      @meetings = @meeting_repo.desc_by_date
+    end
+  end
+end

--- a/apps/web/controllers/meeting/show.rb
+++ b/apps/web/controllers/meeting/show.rb
@@ -1,0 +1,14 @@
+module Web::Controllers::Meeting
+  class Show
+    include Web::Action
+    expose :meeting
+
+    def initialize(meeting_repo: MeetingRepository.new)
+      @meeting_repo = meeting_repo
+    end
+
+    def call(params)
+      @meeting = @meeting_repo.find_with_articles(params[:id])
+    end
+  end
+end

--- a/apps/web/helpers/article_helper.rb
+++ b/apps/web/helpers/article_helper.rb
@@ -1,0 +1,9 @@
+module Web
+  module Helpers
+    module ArticleHelper
+      def article_numbered_title(article)
+         "(#{article.number.nil? ? '番号なし' : article.number}) #{article.title}"
+      end
+    end
+  end
+end

--- a/apps/web/templates/meeting/index.html.erb
+++ b/apps/web/templates/meeting/index.html.erb
@@ -1,0 +1,9 @@
+<p><a href='<%= routes.root_path %>'>Top Page</a></p>
+<h1>ブロック会議日程 一覧</h1>
+<div>
+  <ul>
+    <% meetings.each do |meeting| %>
+      <li><a href='<%= routes.meeting_path(id: meeting.id) %>'><%= meeting.date %></a></li>
+    <% end %>
+  </ul>
+</div>

--- a/apps/web/templates/meeting/show.html.erb
+++ b/apps/web/templates/meeting/show.html.erb
@@ -1,0 +1,18 @@
+<p><a href='<%= routes.root_path %>'>Top Page</a></p>
+<p><a href='<%= routes.meetings_path %>'>ブロック会議一覧へ戻る</a></p>
+<h1><%= meeting.date %></h1>
+<div>
+  <h2>議案一覧</h2>
+  <ul>
+  <% meeting.articles.each do |article| %>
+  <div class="article">
+    <h1>
+      <a href="<%= routes.article_path(id: article.id) %>">
+        <%= article_numbered_title(article) %>
+      </a>
+    </h1>
+    <p><%= article.body %></p>
+  </div>
+  <% end %>
+  </ul>
+</div>

--- a/apps/web/views/meeting/index.rb
+++ b/apps/web/views/meeting/index.rb
@@ -1,0 +1,5 @@
+module Web::Views::Meeting
+  class Index
+    include Web::View
+  end
+end

--- a/apps/web/views/meeting/show.rb
+++ b/apps/web/views/meeting/show.rb
@@ -1,0 +1,5 @@
+module Web::Views::Meeting
+  class Show
+    include Web::View
+  end
+end

--- a/spec/web/controllers/meeting/index_spec.rb
+++ b/spec/web/controllers/meeting/index_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../../spec_helper'
+
+describe Web::Controllers::Meeting::Index do
+  let(:meetings) { [Meeting.new(id: rand(1..5))] }
+  let(:params) { Hash[] }
+
+  it 'is successful' do
+    action = Web::Controllers::Meeting::Index.new(
+      meeting_repo: MiniTest::Mock.new.expect(:desc_by_date, meetings)
+    )
+    response = action.call(params)
+
+    response[0].must_equal 200
+    action.meetings.must_equal meetings
+  end
+end

--- a/spec/web/controllers/meeting/show_spec.rb
+++ b/spec/web/controllers/meeting/show_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../../spec_helper'
+
+describe Web::Controllers::Meeting::Show do
+  let(:articles) { [Article.new(id: rand(1..5))] }
+  let(:meeting) { Meeting.new(id: rand(1..5), articles: articles) }
+  let(:params) { {id: meeting.id} }
+
+  it 'is successful' do
+    action = Web::Controllers::Meeting::Show.new(
+      meeting_repo: MiniTest::Mock.new.expect(:find_with_articles, meeting, [meeting.id])
+    )
+    response = action.call(params)
+    response[0].must_equal 200
+    action.meeting.must_equal meeting
+  end
+end

--- a/spec/web/views/meeting/index_spec.rb
+++ b/spec/web/views/meeting/index_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../../spec_helper'
+
+describe Web::Views::Meeting::Index do
+  let(:exposures) { Hash[format: :html] }
+  let(:template)  { Hanami::View::Template.new('apps/web/templates/meeting/index.html.erb') }
+  let(:view)      { Web::Views::Meeting::Index.new(template, exposures) }
+  let(:rendered)  { view.render }
+
+  it 'exposes #format' do
+    view.format.must_equal exposures.fetch(:format)
+  end
+end

--- a/spec/web/views/meeting/show_spec.rb
+++ b/spec/web/views/meeting/show_spec.rb
@@ -1,0 +1,12 @@
+require_relative '../../../spec_helper'
+
+describe Web::Views::Meeting::Show do
+  let(:exposures) { Hash[format: :html] }
+  let(:template)  { Hanami::View::Template.new('apps/web/templates/meeting/show.html.erb') }
+  let(:view)      { Web::Views::Meeting::Show.new(template, exposures) }
+  let(:rendered)  { view.render }
+
+  it 'exposes #format' do
+    view.format.must_equal exposures.fetch(:format)
+  end
+end


### PR DESCRIPTION
ブロック会議の一覧を表示する`meeting#index`と、そのうち一つのブロック会議に含まれる議案一覧を表示する`meeting#show`アクションを実装し、それぞれテストも追加した