### PR TITLE
Revert "Bump tzinfo from 1.2.7 to 1.2.10"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     transproc (1.1.1)
-    tzinfo (1.2.10)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     tzinfo-data (1.2020.1)
       tzinfo (>= 1.0.0)


### PR DESCRIPTION
Reverts kumano-dormitory/kumanodocs-hanami#131
うまくいかないので一旦保留